### PR TITLE
fix: require requests>=2.25.1, first to support urllib3>=1.26 (#15)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 edgegrid-python==1.1.1
-requests==2.23.0
+requests>=2.25.1,<3.0
 click==7.1.1
 urllib3>=1.26.5
 chardet==3.0.4


### PR DESCRIPTION
This upgrades the requests library minimum requirement to 2.25.1 to support the change made in #14.

