### PR TITLE
Allow group_id for single-host #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides a way to onboard a new Akamai Property Manager configuration using any flexible user-defined setup. You can include any desired settings (subject to authorization and entitlements) such as:
 
-- Any property mangager configuration json rule template
+- Any property manager configuration json rule template
 - Standard TLS or Enhanced TLS Network
 - Use new or existing SSL Certificates and Edge Hostnames
 - Include in existing WAF configurations (Add Selected Hosts and/or Match Targets)
@@ -12,8 +12,8 @@ Provides a way to onboard a new Akamai Property Manager configuration using any 
 
 In order to use this module, you need to:
 
-- Set up your credentials in your .edgerc file
-- The default section used in your configuration file should be called 'onboard'. If you wish to override, you may also use the --section <name> to use the specific section credentials from your .edgerc file
+- Set up your credentials in your `.edgerc` file
+- The default section used in your configuration file should be called `onboard`. If you wish to override, you may also use the `--section <section_name>` to use the specific section credentials from your `.edgerc` file
 - Your API credential should include at least the following grants:
   - Property Manager (/papi)
   - Edge Hostnames API (/hapi)
@@ -28,37 +28,16 @@ access_token = [ACCESS_TOKEN_HERE]
 client_token = [CLIENT_TOKEN_HERE]
 ```
 
-## Akamai CLI Install
+## Akamai Onboard CLI Install
 
 ```bash
 %  akamai install onboard
 %  akamai install property-manager (if not already installed)
 ```
 
-## Local Install
-
-- Minimum python 3.10
-- Clone repository
-
-```bash
-git clone https://github.com/akamai/cli-onboard.git
-```
-
-- Create python virtual environment
-
-```bash
-python3 -m venv .venv
-```
-
-- Install required packages
-
-```bash
-pip3 install -r requirements.txt
-```
-
 # Onboard Types
 
-This CLI has 2 command types for onboarding new properties:
+This CLI has 4 command types for onboarding new properties:
 
 - [create](#create)
 - [single-host](#single-host)
@@ -172,7 +151,7 @@ Sample **templates/sample_setup_files/create.json** for an initial empty setup f
 **file_info**
 
 - **use_file**: Specify true if you want to use a single file json template
-- **source_template_file**: File path to single file json template. This file can have ${env.variable} references to serve place holders that will be substitued from values in source_values_file
+- **source_template_file**: File path to single file json template. This file can have `${env.variable}` references to serve place holders that will be substituted from values in source_values_file
 - **source_values_file**: File path to the single file variable values. This source values file can look like this:
 
 ```bash
@@ -186,7 +165,7 @@ Sample **templates/sample_setup_files/create.json** for an initial empty setup f
 
 - **use_folder**: Specify true if you want to use an existing Akamai pipeline folder structure. This folder should contain the projectInfo.json and environments folder
 - **folder_path**: File path to the Akamai pipeline folder
-- **env_name**: Environment name to build. This name should be defined in projectInfo.json and have corrent setting and variable values in environments folder
+- **env_name**: Environment name to build. This name should be defined in `projectInfo.json` and have correct setting and variable values in environments folder
 
 **public_hostnames**
 
@@ -195,52 +174,56 @@ Sample **templates/sample_setup_files/create.json** for an initial empty setup f
 **edge_hostname**
 
 - For a new property manager configuration, we can use an existing edge hostname, create a new standard_tls edge hostname, or create a new enhanced_tls edge hostname
-- **mode**: Should be one of: use_existing_edgehostname, new_standard_tls_edgehostname, new_enhanced_tls_edgehostname, secure_by_default
+- **mode**: Should be one of: `use_existing_edgehostname, new_standard_tls_edgehostname, new_enhanced_tls_edgehostname, secure_by_default`
 
 **use_existing_edgehostname**
 
 - **edge_hostname**: Specify the existing edge hostname to use.
-  - If using ENHANCED_TLS, this should end with **edgekey.net**
-  - If using STANDARD_TLS, this should end with **edgesuite.net**
+  - If using `ENHANCED_TLS`, this should end with `edgekey.net`
+  - If using `STANDARD_TLS`, this should end with `edgesuite.net`
 
 **new_enhanced_tls_edgehostname -- use existing enrollment**
 
-- **use_existing_enrollment_id**: Set to true if you want to create a new edge hostname from an existing certificate enrollment. If true, you must also put in values for the existing_enrollment_id.
+- **use_existing_enrollment_id**: Set to `true` if you want to create a new edge hostname from an existing certificate enrollment. If true, you must also put in value for the existing_enrollment_id.
 - **existing_enrollment_id**: Enrollment ID of the existing certificate
 
 **new_enhanced_tls_edgehostname -- create new enrollment**
 
-- **create_new_ssl_cert**: Set to true if you want to brand new certificate enrollment. If true, you must also put in values for the ssl_cert_template_file, ssl_cert_template_values, and use_temp_existing_edge_hostname_id (NOT USED ANYMORE)
+- **create_new_ssl_cert**: Set to `true` if you want to brand new certificate enrollment. If true, you must also put in values for the ssl_cert_template_file, ssl_cert_template_values, and use_temp_existing_edge_hostname_id **(NOT USED ANYMORE)**
 - **ssl_cert_template_file**: File path to ssl certificate template json file. This can be for any certificate type (NOT USED ANYMORE)
-- **ssl_cert_template_values**: Values for the ssl certificate template to be used (NOT USED ANYMORE)
-- **temp_existing_edge_hostname**: Due to backend api limitations, a new edge hostname cannot be immediately made that references a newly created certificate enrollment for a brief period of time. Rather than be blocked by this process, specify a temporary edge hostname to use as a placeholder. This value is not really used and just a place holder to proceed with the property manager configuration creation. If using ENHANCED_TLS, use an existing edge hostname ends with edgekey.net ; otherwise if using STANDARD_TLS, use an existing edge hostname that ends with edgesuite.net (NOT USED ANYMORE)
+- **ssl_cert_template_values**: Values for the ssl certificate template to be used **(NOT USED ANYMORE)**
+- **temp_existing_edge_hostname**: Due to backend api limitations, a new edge hostname cannot be immediately made that references a newly created certificate enrollment for a brief period of time. Rather than be blocked by this process, specify a temporary edge hostname to use as a placeholder. This value is not really used and just a place holder to proceed with the property manager configuration creation. If using `ENHANCED_TLS`, use an existing edge hostname ends with `edgekey.net` ; otherwise if using `STANDARD_TLS`, use an existing edge hostname that ends with `edgesuite.net` **(NOT USED ANYMORE)**
 
 **secure_by_default -- provision secure by default certificates**
 
-- **create_new_edge_hostnames**: set to **true** if you want a new unique edge hostname created for each onboarded hostname. The edge hostnames created will be in the form **{hostname}.edgekey.net**
-- **use_existing_edge_hostname**: add an existing edge hostname to use - it must be **SNI**. All Secure by Default certificates are SNI.
+- **create_new_edge_hostnames**: set to **true** if you want a new unique edge hostname created for each onboarded hostname. The edge hostnames created will be in the form `{hostname}.edgekey.net`
+- **use_existing_edge_hostname**: add an existing edge hostname to use - it must be **SNI**. All Secure by Default certificates are `SNI`.
 
 **update_waf_info**
 
-- **add_selected_host**: Set to **true** if you want to add specified public_hostnames to WAF selected hosts
+- **add_selected_host**: Set to `true` if you want to add specified public_hostnames to WAF selected hosts
 - **waf_config-name**: Name of security configuration
-- **update_match_target**: Set to **true** if you want to add specified public_hostnames to specifed waf_match_target_id
+- **update_match_target**: Set to `true` if you want to add specified public_hostnames to specified waf_match_target_id
 - **waf_match_target_id**: waf match target id to add hostnames to (use numeric waf match target id)
-- NOTE: If you do not know the match target id, leave the value as 0 and execute the onboarding. The validation steps will print out the existing match target IDs for the WAF config selected.
-- NOTE: These settings can only happen if property manager configuration is activated to Akamai staging
+- NOTE: If you do not know the match target id, leave the value as `0` and execute the onboarding. The validation steps will print out the existing match target IDs for the WAF config selected.
+- NOTE: These settings can only happen if property manager configuration is activated on the Akamai Staging network
 
 **activate settings**
 
-- **activate_property_staging**: Activate property manager configuration to staging network
-- **activate_property_production**: Activate property manager configuration to production network (must go through staging first)
-- **activate_waf_policy_staging**: Activate security configuration to staging network
-- **activate_waf_policy_production**: Activate security configuration to production network (must go through staging first)
+- **activate_property_staging**: Activate property manager configuration to `staging` network
+- **activate_property_production**: Activate property manager configuration to `production` network (must go through staging first)
+- **activate_waf_policy_staging**: Activate security configuration to `staging` network
+- **activate_waf_policy_production**: Activate security configuration to `production` network (must go through staging first)
 - **notification_emails**: Array of emails to be notified after activations
 </details>
 
 <br/><br/>
 
 # single-host
+
+### Description
+
+single-host creates a property with one public hostname at the top level of the contract unless group_id is specified in the JSON file.
 
 ### Example Usage
 
@@ -279,28 +262,29 @@ akamai onboard single-host --file ~/path/to/single.json
     <summary>Show me</summary>
 
 - **contract_id**: Contract ID (starts with ctr\_)
-- **product_id**: Product ID: one of prd_SPM, prd_Fresca, prd_API_Accel (case sensitive)
-- **property_hostname**: Public facing hostname
+- **product_id**: Product ID: one of `prd_SPM`, `prd_Fresca`,`prd_API_Accel` (case sensitive)
+- **property_hostname**: Public facing hostname. This will be used as the name of the property.
 - **property_origin**: Origin hostname for property_hostname
-- **activate_production**: Activate to Akamai production network (will always update to Akamai staging already)
+- **activate_production**: Activate to Akamai `production` network (single-mode will always activate property on the Akamai staging)
 - **notification_emails**: Array of emails to be notified after activations
 
----
+**Optional Values:**
+
+- **group_id**: Group ID (starts with grp\_) If you do not have security at the contract/top level or you would like to put the property on a specify property group.
+- **version_notes**: Allow you to override the default value `Initial Version`
 
 **edge_hostname**
 
 - **secure_by_default**: set to **true** if you want to provision a default certificate for the hostname. This will automatically create a new edge hostname.
-- **use_existing_edge_hostname**: specify existing edge hostname to use (must already exist). Will not be used if 'secure_by_default' is set to true.
+- **use_existing_edge_hostname**: specify existing edge hostname to use (must already exist). Value will not be used if `secure_by_default` is set to `true`.
 - **create_from_existing_enrollment_id**: create new edge hostname from existing certificate enrollment id (must already exist)
-
----
 
 **update_waf_info**
 
 - **create_new_security_config**:
-  - set to **true** will create default security configuration in **alert** mode
-  - set to **false** will not create a security configuration
-- **waf_config_name**: name of new security config to be created (if blank, will use default "WAF Security File" as name
+  - set to `true` will create default security configuration in `alert` mode
+  - set to `false` will not create a security configuration
+- **waf_config_name**: name of new security config to be created. If `blank`, the default policy will be `WAF Security File`
 </details>
 
 <br></br>
@@ -373,9 +357,9 @@ www.example.com,origin.example.com,new_property_1,ORIGIN_HOSTNAME,www.example.co
 - **hostname**: [required] Hostname that you want to onboard
 - **origin**: [required] Origin hostname
 - **propertyName**: Name of property. If empty or column is missing, defaults to hostname.
-- - If 2 rows have the same propertyName, the hostnames will be added to the same property and an origin behavior ruleset will be injected into the inputed template
-- **forwardHostHeader**: Host header used on forward request to origin. Can be either 'REQUEST_HOST_HEADER' or 'ORIGIN_HOSTNAME'. If empty or column is missing, defaults to 'REQUEST_HOST_HEADER'. This setting will override whatever is in the input template default origin behavior.
-- **edgeHostname**: [required unless using secure_by_default] The edge hostname to map the hostname to. The edge hostname must already exist. Batch-create mode does NOT create new edge hostnames unless secure-by-default mode is being used
+- - If 2 rows have the same propertyName, the hostnames will be added to the same property and an origin behavior ruleset will be injected into the input template
+- **forwardHostHeader**: Host header used on forward request to origin. Can be either `INCOMING_HOST_HEADER` or `ORIGIN_HOSTNAME`. If empty or column is missing, defaults to `INCOMING_HOST_HEADER`. This setting will override whatever is in the input template default origin behavior.
+- **edgeHostname**: [required unless using secure_by_default] The edge hostname to map the hostname to. The edge hostname must already exist. batch-create mode `does NOT` create new edge hostnames unless secure-by-default mode is being used.
 
 </details>
 
@@ -391,11 +375,11 @@ www.example.com,origin.example.com,new_property_1,ORIGIN_HOSTNAME,www.example.co
 - **--group** **-g**: Group ID (starts with grp\_) [required]
 - **--product** **-p**: Product ID (usually starts with prd\* and should be one of available products from specified contract_id) [required]
 - **--rule-format** **-f**: Rule format (typically latest, but can you frozen rule format if desired) [default:latest]
-- **--use-cpcode**: Override creation of newcpcodes and use single cpcode for all properties
+- **--use-cpcode**: Override creation of new cpcodes and use single cpcode for all properties
 - **--secure-by-default**: Use secure by default certificates
 - **--waf-config**: name of security configuration to update
 - **--waf-match-target**: waf match target id to add hostnames to (use numeric waf match target id)
-- **--activate**: Activation networks. If activating waf on a network, delivery must also be activated. Options: delivery-staging, delivery-production, waf-staging, waf-production
+- **--activate**: Activation networks. If activating waf on a network, delivery must also be activated. Options: `delivery-staging`, `delivery-production`, `waf-staging`, `waf-production`
 - **--email**: email(s) for activation notifications
 
 </details>
@@ -404,11 +388,17 @@ www.example.com,origin.example.com,new_property_1,ORIGIN_HOSTNAME,www.example.co
 
 # fetch-sample-templates
 
-This will create a folder called sample_setup_files locally so you will have sample setup in both JSON and CSV format depending on the command you choose the onboard.
+This will create a folder called `sample_setup_files` locally so you will have sample setups in both JSON and CSV format depending on the command you choose the onboard.
 
 # Contribution
 
 By submitting a contribution (the “Contribution”) to this project, and for good and valuable consideration, the receipt and sufficiency of which are hereby acknowledged, you (the “Assignor”) irrevocably convey, transfer, and assign the Contribution to the owner of the repository (the “Assignee”), and the Assignee hereby accepts, all of your right, title, and interest in and to the Contribution along with all associated copyrights, copyright registrations, and/or applications for registration and all issuances, extensions and renewals thereof (collectively, the “Assigned Copyrights”). You also assign all of your rights of any kind whatsoever accruing under the Assigned Copyrights provided by applicable law of any jurisdiction, by international treaties and conventions and otherwise throughout the world.
+
+## Local Install
+
+- Minimum python 3.6 `git clone https://github.com/akamai/cli-onboard.git  `
+- Create python virtual environment `python3 -m venv .venv`
+- Install required packages `pip3 install -r requirements.txt`
 
 # Notice
 

--- a/bin/akamai-onboard.py
+++ b/bin/akamai-onboard.py
@@ -315,7 +315,8 @@ def single_host(config, file):
 
     # Override default
     util.onboard_override_default(onboard, setup, cli_mode='single-host')
-    util.validate_group_id(onboard, wrap_api.get_groups_without_parent())
+    if not onboard.group_id:
+        util.validate_group_id(onboard, wrap_api.get_groups_without_parent())
     util.validateSetupSteps(onboard, wrap_api, cli_mode='single_host')
     if util.valid:
         # Load business rule for delivery and security
@@ -719,7 +720,8 @@ def batch_create(config, **kwargs):
         return 0
 
     return 0
-    
+
+
 def get_prog_name():
     prog = os.path.basename(sys.argv[0])
     if os.getenv('AKAMAI_CLI'):

--- a/bin/onboard_single_host.py
+++ b/bin/onboard_single_host.py
@@ -65,6 +65,11 @@ class onboard:
         except:
             self.version_notes = ''
 
+        try:
+            self.group_id = json_input['property_info']['group_id']
+        except:
+            self.group_id = ''
+
         self.write_variable_json()
 
     def write_variable_json(self) -> None:

--- a/bin/utility.py
+++ b/bin/utility.py
@@ -851,6 +851,8 @@ class utility:
     def onboard_override_default(self, onboard, setup, cli_mode: str) -> None:
         if cli_mode == 'single-host':
             onboard.new_cpcode_name = setup.new_cpcode_name
+            onboard.group_id = setup.group_id
+            onboard.secure_network = 'STANDARD_TLS' if setup.edge_hostname.endswith('edgesuite.net') else onboard.secure_network
             template_path = f'{root}/templates/akamai_product_templates'
             onboard.source_values_file = f'{template_path}/single_variable.json'
         elif cli_mode == 'multi-hosts':


### PR DESCRIPTION
Allow users to modify group_id in the setup JSON file because not all customers have access to the top level (contract level).  