### PR TITLE
Bump edgegrid-python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cerberus==1.3.4
 chardet==3.0.4
 click==7.1.1
 coloredlogs==15.0.1
-edgegrid-python==1.1.1
+edgegrid-python==1.3.1
 pandas==2.0.0
 pyIsEmail==2.0.1
 requests>=2.25.1,<3.0


### PR DESCRIPTION
When trying to install cli-onboard from akamai-cli, we are facing dependencies errors related to the `edgegrid-python` used (definitely outdated, July 2018)

This PR bumps the version specified in [requirements.txt](requirements.txt)

**Error message :** 

```
Installing collected packages: pycparser, cffi, cryptography, urllib3, six, pyOpenSSL, pyasn1, mdurl, idna, charset-normalizer, certifi, tzdata, setuptools, requests, pytz, python-dateutil, pygments, numpy, ndg-httpsclient, markdown-it-py, humanfriendly,
dnspython, tabulate, rich, pyIsEmail, pandas, edgegrid-python, coloredlogs, click, chardet, cerberus
    Running setup.py install for edgegrid-python: started
    Running setup.py install for edgegrid-python: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /home/toolbox/.akamai-cli/venv/cli-onboard/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-c27asqjh/edgegrid-python_cd6cb10179494dc39877913e69be3ba0/setup.py'"'"'; __file__='"'"'/tmp/pip-install-c27asq
jh/edgegrid-python_cd6cb10179494dc39877913e69be3ba0/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-re
cord-028u9qlm/install-record.txt --single-version-externally-managed --compile --install-headers /home/toolbox/.akamai-cli/venv/cli-onboard/include/site/python3.9/edgegrid-python
         cwd: /tmp/pip-install-c27asqjh/edgegrid-python_cd6cb10179494dc39877913e69be3ba0/
    Complete output (19 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-c27asqjh/edgegrid-python_cd6cb10179494dc39877913e69be3ba0/setup.py", line 2, in <module>
        setup(
      File "/home/toolbox/.akamai-cli/venv/cli-onboard/lib/python3.9/site-packages/setuptools/__init__.py", line 103, in setup
        return distutils.core.setup(**attrs)
      File "/home/toolbox/.akamai-cli/venv/cli-onboard/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 147, in setup
        _setup_distribution = dist = klass(attrs)
      File "/home/toolbox/.akamai-cli/venv/cli-onboard/lib/python3.9/site-packages/setuptools/dist.py", line 303, in __init__
        _Distribution.__init__(self, dist_attrs)
      File "/home/toolbox/.akamai-cli/venv/cli-onboard/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 283, in __init__
        self.finalize_options()
      File "/home/toolbox/.akamai-cli/venv/cli-onboard/lib/python3.9/site-packages/setuptools/dist.py", line 679, in finalize_options
        for ep in sorted(loaded, key=by_order):
      File "/home/toolbox/.akamai-cli/venv/cli-onboard/lib/python3.9/site-packages/setuptools/dist.py", line 678, in <lambda>
        loaded = map(lambda e: e.load(), filtered)
      File "/home/toolbox/.akamai-cli/venv/cli-onboard/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/__init__.py", line 210, in load
        return functools.reduce(getattr, attrs, module)
    AttributeError: type object 'Distribution' has no attribute '_finalize_feature_opts'
    ----------------------------------------
ERROR: Command errored out with exit status 1: /home/toolbox/.akamai-cli/venv/cli-onboard/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-c27asqjh/edgegrid-python_cd6cb10179494dc39877913e69be3ba0/setup.py'"'"'; __fi
le__='"'"'/tmp/pip-install-c27asqjh/edgegrid-python_cd6cb10179494dc39877913e69be3ba0/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"
'))' install --record /tmp/pip-record-028u9qlm/install-record.txt --single-version-externally-managed --compile --install-headers /home/toolbox/.akamai-cli/venv/cli-onboard/include/site/python3.9/edgegrid-python Check the logs for full command output.
```
