### PR TITLE
Migrate cerberus to jsonschema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,10 @@
 
 - appsec-create fail on brand new group without any config
 - appsec-create version/activation note is empty
+
+## 2.3.7
+
+#### ENHANCEMENTS:
+
+- Replaced `cerberus` with `jsonschema`
+- Upgraded `pandas` to version `2.2.2`

--- a/bin/akamai-onboard.py
+++ b/bin/akamai-onboard.py
@@ -49,7 +49,7 @@ from model.multi_hosts import MultiHosts
 from model.single_host import SingleHost
 from tabulate import tabulate
 
-PACKAGE_VERSION = '2.3.6'
+PACKAGE_VERSION = '2.3.7'
 logger = setup_logger()
 root = get_cli_root_directory()
 
@@ -112,7 +112,7 @@ def init_config(config):
 @pass_config
 def cli(config, edgerc, section, account_key):
     '''
-    Akamai CLI for onboarding properties v2.3.4
+    Akamai CLI for onboarding properties v2.3.7
     '''
     config.edgerc = edgerc
     config.section = section

--- a/bin/utility.py
+++ b/bin/utility.py
@@ -15,7 +15,7 @@ from time import strftime
 from urllib import parse
 
 import pandas as pd
-from cerberus import Validator
+from jsonschema import validate, ValidationError
 from distutils.dir_util import copy_tree
 from exceptions import get_cli_root_directory
 from exceptions import setup_logger
@@ -1025,19 +1025,16 @@ class utility:
                 'regex': (r'(.*\.edgekey\.net$|.*\.edgesuite\.net$)')}
         }
 
-        v = Validator(schema)
         logger.warning(f'Reading customer property name input: {csv_file_loc}')
 
         with open(csv_file_loc, encoding='utf-8-sig', newline='') as f:
             for i, row in enumerate(csv.DictReader(f), 1):
                 csv_dict.append(row)
-                valid = v.validate(row)
-                validation_errors = v.errors
-                if validation_errors:
+                try:
+                    validate(instance=row, schema=schema)
+                except ValidationError as e:
                     onboard_object.valid_csv = False
-                    logger.warning(f'CSV Validation Error in row: {i}...')
-                    for error in validation_errors:
-                        logger.warning(f'{error} {validation_errors[error]}')
+                    logger.warning(f'CSV Validation Error in row: {i} - {e}')
 
         onboard_object.csv_dict = csv_dict
         return onboard_object.valid_csv
@@ -1056,19 +1053,16 @@ class utility:
             }
         }
 
-        v = Validator(schema)
         logger.warning(f'Reading csv input: {csv_file_loc}')
 
         with open(csv_file_loc, encoding='utf-8-sig', newline='') as f:
             for i, row in enumerate(csv.DictReader(f), 1):
                 csv_dict.append(row)
-                valid = v.validate(row)
-                validation_errors = v.errors
-                if validation_errors:
+                try:
+                    validate(instance=row, schema=schema)
+                except ValidationError as e:
                     onboard_object.valid_csv = False
-                    logger.warning(f'CSV Validation Error in row: {i}...')
-                    for error in validation_errors:
-                        logger.warning(f'{error} {validation_errors[error]}')
+                    logger.warning(f'CSV Validation Error in row: {i} - {e}')
 
         onboard_object.csv_dict = csv_dict
         return onboard_object.valid_csv
@@ -1344,18 +1338,18 @@ class utility:
                                'required': False},
                  }
 
-        v = Validator(schema)
         logger.warning(f'Reading customer security configuration input: {csv_file_loc}')
         valid = True
         with open(csv_file_loc, encoding='utf-8-sig', newline='') as f:
             data = []
             for i, row in enumerate(csv.DictReader(f), 1):
                 data.append(row)
-                v.validate(row)
-                if v.errors:
+                try:
+                    validate(instance=row, schema=schema)
+                except ValidationError as e:
                     valid = False
-                    for error in v.errors:
-                        logger.error(f'CSV Validation Error in row: {i} {error}')
+                    logger.error(f'CSV Validation Error in row: {i} - {e}')
+
         return valid, data
 
     def csv_2_appsec_create_by_propertyname(self, csv_file_loc: str):
@@ -1373,18 +1367,18 @@ class utility:
                                'required': False}
                  }
 
-        v = Validator(schema)
         logger.warning(f'Reading customer security configuration input: {csv_file_loc}')
         valid = True
         with open(csv_file_loc, encoding='utf-8-sig', newline='') as f:
             data = []
             for i, row in enumerate(csv.DictReader(f), 1):
                 data.append(row)
-                v.validate(row)
-                if v.errors:
+                try:
+                    validate(instance=row, schema=schema)
+                except ValidationError as e:
                     valid = False
-                    for error in v.errors:
-                        logger.error(f'CSV Validation Error in row: {i} {error}')
+                    logger.error(f'CSV Validation Error in row: {i} - {e}')
+
         return valid, data
 
     def populate_waf_data(self, by: str, input: dict) -> dict:

--- a/cli.json
+++ b/cli.json
@@ -8,7 +8,7 @@
       "aliases": [
         "onboard"
       ],
-      "version": "2.3.6",
+      "version": "2.3.7 ",
       "description": "Onboard Akamai delivery and WAF configuration"
     }
   ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-cerberus==1.3.4
 chardet==3.0.4
 click==7.1.1
 coloredlogs==15.0.1
 edgegrid-python==1.3.1
-pandas==2.1.2
+jsonschema==4.23.0
+pandas==2.2.2
 pyIsEmail==2.0.1
 requests>=2.25.1,<3.0
 rich==13.3.2


### PR DESCRIPTION
While building Docker images for cli-onboard ([repository link](https://git.source.akamai.com/projects/DEVEXP/repos/akamai-docker/)), we have observed an increase in both the build time and the size of the images.

Before:
akamai/onboard amd64: 251MB
akamai/onboard arm64: 300MB

After:
akamai/onboard amd64: 169MB
akamai/onboard arm64: 160MB

To address this, we plan to use pre-built wheels. However, we encountered the following issues:

1. Missing Wheel for Cerberus 1.3.4:
As noted in [this GitHub issue](https://github.com/pyeve/cerberus/issues/577), the wheel for Cerberus 1.3.4 is missing on PyPI, and there is no ongoing maintenance for Cerberus. It's suggested to switch to python-jsonschema instead.

2. No Wheels for Pandas 2.1.2:
The required wheels for Pandas 2.1.2 are also unavailable.

Solution:
This PR replaces Cerberus with jsonschema. Additionally, to utilize wheels, it's necessary to upgrade to Pandas 2.2.2.